### PR TITLE
allow custom mappings

### DIFF
--- a/ftplugin/timesheet.vim
+++ b/ftplugin/timesheet.vim
@@ -2,15 +2,16 @@
 function! s:NewTimesheetEntry()
 	" Go to the end of the file, because that's the only place where
 	" inserting a new timestamped item makes sense.
-	normal G
+	call cursor(line('$'), 0)
 	" Look backwards for a date.
 	let l:dateline = search('\v^\d{4}-\d{2}-\d{2}:$', 'bcnw')
 	" If there's none or it's not the current day, create one.
 	if !l:dateline || getline(l:dateline) != strftime("%Y-%m-%d:")
-		execute "normal o\n" . strftime("%Y-%m-%d:")
+		call append(line('$'), '')
+		call append(line('$'), strftime("%Y-%m-%d:"))
 	endif
 	" Insert the timestamp and start insert mode.
-	execute "normal o" . strftime("%H%M")
+	call append(line('$'), strftime("%H%M"))
 endfunction
 
 nnoremap <Plug>(Timesheet) :call <SID>NewTimesheetEntry()<CR>

--- a/ftplugin/timesheet.vim
+++ b/ftplugin/timesheet.vim
@@ -19,6 +19,6 @@ nnoremap <Plug>(Timesheet) :call <SID>NewTimesheetEntry()<CR>
 " Some mappings to insert a timestamped new line.
 if !hasmapto('<Plug>(Timesheet)')
 	nmap <buffer> <LocalLeader>n <Plug>(Timesheet)GA<Space><Space>
-	nmap <buffer> <LocalLeader>s <Plug>(Timesheet)GA.<Esc>
-	nmap <buffer> <LocalLeader>c <Plug>(Timesheet)GA^<Esc>
+	nmap <buffer> <LocalLeader>s <Plug>(Timesheet)GA.<C-C>
+	nmap <buffer> <LocalLeader>c <Plug>(Timesheet)GA^<C-C>
 endif

--- a/ftplugin/timesheet.vim
+++ b/ftplugin/timesheet.vim
@@ -1,9 +1,5 @@
-" Create a new entry.
-" followed_by:        string to append after the timestamp
-" optional parameter: set to false (e.g. 0) to _not_ go into insert mode
-"                     afterwards
-function! s:NewTimesheetEntry(followed_by, ...)
-	let l:insertmode = get(a:, 1, 1)
+" Create a new timestamp entry at the end of the file.
+function! s:NewTimesheetEntry()
 	" Go to the end of the file, because that's the only place where
 	" inserting a new timestamped item makes sense.
 	normal G
@@ -14,19 +10,14 @@ function! s:NewTimesheetEntry(followed_by, ...)
 		execute "normal o\n" . strftime("%Y-%m-%d:")
 	endif
 	" Insert the timestamp and start insert mode.
-	execute "normal o" . strftime("%H%M") . a:followed_by
-	if l:insertmode
-		startinsert!
-	endif
+	execute "normal o" . strftime("%H%M")
 endfunction
 
-nnoremap <Plug>TimesheetStart    :call <SID>NewTimesheetEntry('  ')<CR>
-nnoremap <Plug>TimesheetStop     :call <SID>NewTimesheetEntry('.', 0)<CR>
-nnoremap <Plug>TimesheetContinue :call <SID>NewTimesheetEntry('^', 0)<CR>
+nnoremap <Plug>(Timesheet) :call <SID>NewTimesheetEntry()<CR>
 
 " Some mappings to insert a timestamped new line.
-if !hasmapto('<Plug>TimesheetStart')
-	nmap <buffer> <LocalLeader>n <Plug>TimesheetStart
-	nmap <buffer> <LocalLeader>s <Plug>TimesheetStop
-	nmap <buffer> <LocalLeader>c <Plug>TimesheetContinue
+if !hasmapto('<Plug>(Timesheet)')
+	nmap <buffer> <LocalLeader>n <Plug>(Timesheet)GA<Space><Space>
+	nmap <buffer> <LocalLeader>s <Plug>(Timesheet)GA.<Esc>
+	nmap <buffer> <LocalLeader>c <Plug>(Timesheet)GA^<Esc>
 endif

--- a/ftplugin/timesheet.vim
+++ b/ftplugin/timesheet.vim
@@ -20,7 +20,13 @@ function! s:NewTimesheetEntry(followed_by, ...)
 	endif
 endfunction
 
+nnoremap <Plug>TimesheetStart    :call <SID>NewTimesheetEntry('  ')<CR>
+nnoremap <Plug>TimesheetStop     :call <SID>NewTimesheetEntry('.', 0)<CR>
+nnoremap <Plug>TimesheetContinue :call <SID>NewTimesheetEntry('^', 0)<CR>
+
 " Some mappings to insert a timestamped new line.
-nnoremap <buffer> <LocalLeader>n :call <SID>NewTimesheetEntry('  ')<CR>
-nnoremap <buffer> <LocalLeader>s :call <SID>NewTimesheetEntry('.', 0)<CR>
-nnoremap <buffer> <LocalLeader>c :call <SID>NewTimesheetEntry('^', 0)<CR>
+if !hasmapto('<Plug>TimesheetStart')
+	nmap <buffer> <LocalLeader>n <Plug>TimesheetStart
+	nmap <buffer> <LocalLeader>s <Plug>TimesheetStop
+	nmap <buffer> <LocalLeader>c <Plug>TimesheetContinue
+endif


### PR DESCRIPTION
Map `s:NewTimesheetEntry()` to `<Plug>(Timesheet)` so users can customise it. If they do, avoid the default Leader key bindings.

Personally I prefer to override `o` to insert a new entry, especially as `\n` etc are already occupied here. Also `O` instead of `\c` and `do` instead of `\s`.